### PR TITLE
Add GetGob and SetGob

### DIFF
--- a/kc/kc_gob_test.go
+++ b/kc/kc_gob_test.go
@@ -1,0 +1,32 @@
+// Copyright 2012 Francisco Souza. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package kc
+
+import (
+	"testing"
+)
+
+func TestShouldBeAbleToSetAndGetANativeGoType(t *testing.T) {
+	if db, err := Open("-", WRITE); err == nil {
+		defer db.Close()
+
+		data := make(map[string]int)
+		data["one"] = 1
+		data["two"] = 2
+
+		db.SetGob("numbers", data)
+
+		var numbers map[string]int
+		err := db.GetGob("numbers", &numbers)
+		if err != nil {
+			t.Errorf("Failed to get gob: %s", err)
+		}
+		if numbers["one"] != 1 || numbers["two"] != 2 {
+			t.Error("Should transparently persist complex types")
+		}
+	} else {
+		t.Error("Failed to open a prototype hash database")
+	}
+}


### PR DESCRIPTION
Adds support for storing and retrieving arbitrary go structures with GetGob and SetGob.

I would have liked to reduce some of the duplication in the Get/Set functions, but I couldn't come up with a nice way to do it without breaking the GetInt/SetInt tests.

This solves my particular use-case, but doesn't fix the underlying problem that `Get()` should really be using `C.GoStringN(...)` to safely retrieve values. That, however, would break GetInt(), which is dependent on Get truncating values like, `"\0\0\0\0\0\0\0\n"`.
